### PR TITLE
Clean response for GET and DELETE routes and POST args are mandatory now

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -1,6 +1,6 @@
 import os
 import emr
-from flask import Flask, url_for, request, make_response
+from flask import Flask, url_for, request, make_response,abort
 
 app = Flask(__name__)
 
@@ -12,10 +12,18 @@ def hello_world():
 
 @app.post("/job")
 def schedule_job():
+    request_data=request.get_json()
+    if request_data is None or \
+            "name" not in request_data or \
+            "algorithm" not in request_data or \
+            "entrypoint_arguments" not in request_data:
+        abort(400)
+            
+
     emr_response = emr.schedule(
-        request.json.get("name", None),  # TODO: make mandatory
-        request.json.get("algorithm", 0),  # TODO: make mandatory
-        request.json.get("entrypoint_arguments", None)  # TODO: make mandatory
+        request_data["name"],
+        request_data["algorithm"],
+        request_data["entrypoint_arguments"]
     )
     resp = make_response({"id": emr_response["id"]}, 201)
     resp.headers['Location'] = url_for('get_job', job_id=emr_response["id"])
@@ -26,12 +34,31 @@ def schedule_job():
 
 @app.get("/job/<job_id>")
 def get_job(job_id):
-    return emr.get(job_id)
+    emr_response=emr.get(job_id)
+    if emr_response is None:
+        abort(404)
+
+    resp = make_response(
+                        {
+                            "id": emr_response["jobRun"]["id"],
+                            "createdAt": emr_response["jobRun"]["createdAt"],
+                            "finishedAt": emr_response["jobRun"]["finishedAt"],
+                            "name":emr_response["jobRun"]["name"],
+                            "state": emr_response["jobRun"]["state"],
+                            "stateDetails": emr_response["jobRun"]["stateDetails"],                         
+                        }, 200)
+    resp.headers['Content-Type'] = "application/json; charset=utf-8"    
+    return resp
 
 
 @app.delete("/job/<job_id>")
 def cancel_job(job_id):
-    return emr.cancel(job_id)
+    emr_response=emr.cancel(job_id)
+    resp = make_response({"id": emr_response["id"]}, 200)
+    resp.headers['Location'] = url_for('get_job', job_id=emr_response["id"])
+    resp.headers['Content-Type'] = "application/json; charset=utf-8"
+
+    return resp
 
 
 @app.patch("/job/<job_id>")

--- a/src/app.py
+++ b/src/app.py
@@ -54,6 +54,9 @@ def get_job(job_id):
 @app.delete("/job/<job_id>")
 def cancel_job(job_id):
     emr_response=emr.cancel(job_id)
+    if emr_response is None:
+        abort(409)
+
     resp = make_response({"id": emr_response["id"]}, 200)
     resp.headers['Location'] = url_for('get_job', job_id=emr_response["id"])
     resp.headers['Content-Type'] = "application/json; charset=utf-8"

--- a/src/emr.py
+++ b/src/emr.py
@@ -4,10 +4,6 @@ import os
 import boto3
 from enum import Enum
 
-
-# /results-spark
-
-
 class Algorithms(Enum):
     BLIND_SEARCH = 0
     BBHA = 1

--- a/tools/get_version.sh
+++ b/tools/get_version.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-echo "VERSION=0.1.0"
+echo "VERSION=0.1.1"


### PR DESCRIPTION
@Genarito new responses bodies:

- Example for **GET**:
```
{
    "createdAt": "Wed, 07 Jun 2023 00:21:42 GMT",
    "finishedAt": "Wed, 07 Jun 2023 00:21:49 GMT",
    "id": "0000000324j7c9lq8mc",
    "name": "test-job",
    "state": "CANCELLED",
    "stateDetails": "JobRun CANCELLED successfully."
}
```
- Example for **DELETE**:
```
{
    "id": "0000000324j7c9lq8mc"
}
```

New mandatory object fields for POST
- _name_: str
- _algorithm_: **0** for **BLIND_SEARCH**, **1** for **BBHA**
- _entrypoint_arguments_: (this can be an empty array)
